### PR TITLE
Remove RSpec format options and specify a line number

### DIFF
--- a/plugin/bdd.vim
+++ b/plugin/bdd.vim
@@ -20,7 +20,7 @@ endfunction
 
 function! RunSpec(args)
   let spec = RailsScriptIfExists("rspec")
-  let cmd = spec . " " . a:args . " -fn -c " . @%
+  let cmd = spec . " " . @% . a:args
   execute ":! echo " . cmd . " && " . cmd
 endfunction
 
@@ -42,7 +42,7 @@ function! RunTest(args)
   if @% =~ "\.feature$"
     call RunCucumber(":" . line('.') . a:args)
   elseif @% =~ "\.rb$"
-    call RunSpec("-l " . line('.') . a:args)
+    call RunSpec(":" . line('.') . a:args)
   end
 endfunction
 


### PR DESCRIPTION
- Specify a line number with the new syntax (`file_spec.rb:19` instead of `-l 19`)
- We don't need to pass format options - syntax changed and a user can set them in `.rspec.conf` file.
- Changed syntax for a line number tested on older RSpec 2, also.
