### PR TITLE
Neovim support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2016-05-05
+
+### Added
+
+- Run commands in Neovim with :terminal command.
+
 ## 2016-01-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2016-01-18
+
+### Added
+
+- Support for running Elixir tests.
+
 ## 2015-01-27
 
 ### Added

--- a/plugin/bdd.vim
+++ b/plugin/bdd.vim
@@ -1,6 +1,6 @@
 " bdd.vim
-" Vim functions to run RSpec and Cucumber on the current file and optionally on
-" the spec/scenario under the cursor.
+" Vim functions to run Ruby's RSpec and Cucumber or Elixir's ExUnit on the
+" current file and optionally on the spec/scenario under the cursor.
 
 function! ScriptIfExists(name)
   " Zeus

--- a/plugin/bdd.vim
+++ b/plugin/bdd.vim
@@ -18,21 +18,29 @@ function! ScriptIfExists(name)
   end
 endfunction
 
+function! RunCommand(cmd)
+  if has("nvim")
+    return ":terminal " . a:cmd
+  else
+    return ":! " . a:cmd
+  endif
+endfunction
+
 function! RunSpec(args)
   let spec = ScriptIfExists("rspec")
   let cmd = spec . " " . @% . a:args
-  execute ":! echo " . cmd . " && " . cmd
+  execute RunCommand(cmd)
 endfunction
 
 function! RunCucumber(args)
   let cucumber = ScriptIfExists("cucumber")
   let cmd = cucumber . " " . @% . a:args
-  execute ":! echo " . cmd . " && " . cmd
+  execute RunCommand(cmd)
 endfunction
 
 function! RunExUnit(args)
   let cmd = "mix test" . " " . @% . a:args
-  execute ":! echo " . cmd . " && " . cmd
+  execute RunCommand(cmd)
 endfunction
 
 function! RunTestFile(args)


### PR DESCRIPTION
Runs tests in Neovim with `:terminal` command. This brings back colors from RSpec and Cucumber.

I still didn't figure out how to reopen a test run. Any improvements there would be great.
